### PR TITLE
xn concordances, placetype local, and more

### DIFF
--- a/data/1/1.geojson
+++ b/data/1/1.geojson
@@ -150,7 +150,7 @@
         }
     ],
     "wof:id":1,
-    "wof:lastmodified":1694492036,
+    "wof:lastmodified":1695881145,
     "wof:name":"Null Island",
     "wof:parent_id":0,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.